### PR TITLE
Added support for NPCs Names Distributor.

### DIFF
--- a/cmake/headerlist.cmake
+++ b/cmake/headerlist.cmake
@@ -12,6 +12,8 @@ set(headers ${headers}
 	src/ImGui/Util.h
 	src/Input.h
 	src/LocalHistory.h
+	src/NND_API.h
+	src/NPCNameProvider.h
 	src/PCH.h
 	src/Papyrus.h
 	src/Settings.h

--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -12,6 +12,7 @@ set(sources ${sources}
 	src/ImGui/Util.cpp
 	src/Input.cpp
 	src/LocalHistory.cpp
+	src/NPCNameProvider.cpp
 	src/PCH.cpp
 	src/Papyrus.cpp
 	src/Settings.cpp

--- a/src/Dialogue.cpp
+++ b/src/Dialogue.cpp
@@ -1,6 +1,7 @@
 #include "Dialogue.h"
 
 #include "GlobalHistory.h"
+#include "NPCNameProvider.h"
 #include "ImGui/Styles.h"
 
 TimeStamp::TimeStamp(std::uint64_t a_timeStamp, const std::string& a_format) :
@@ -132,7 +133,7 @@ void TimeStamp::SwitchHourFormat(bool a_12HourFormat)
 Dialogue::Line::Line(RE::TESObjectREFR* a_speaker, const std::string& a_line, const std::string& a_voice) :
 	line(a_line),
 	voice(a_voice),
-	name(a_speaker->GetDisplayFullName()),
+	name(NPCNameProvider::GetSingleton()->GetName(a_speaker)),
 	isPlayer(a_speaker->IsPlayerRef()),
 	hovered(false)
 {}
@@ -156,7 +157,7 @@ void Dialogue::Initialize(RE::TESObjectREFR* a_speaker)
 				locName = "$DH_UnknownLocation"_T;
 			}
 		}
-		speakerName = a_speaker->GetDisplayFullName();
+		speakerName = NPCNameProvider::GetSingleton()->GetName(a_speaker);
 	}
 }
 

--- a/src/GlobalHistory.cpp
+++ b/src/GlobalHistory.cpp
@@ -1,5 +1,6 @@
 #include "GlobalHistory.h"
 
+#include "NPCNameProvider.h"
 #include "Hooks.h"
 #include "Hotkeys.h"
 #include "ImGui/IconsFonts.h"
@@ -386,7 +387,7 @@ namespace GlobalHistory
 					dialogue.locName = "???";
 				}
 
-				dialogue.speakerName = speakerActor->GetDisplayFullName();
+				dialogue.speakerName = NPCNameProvider::GetSingleton()->GetName(speakerActor);
 
 				for (auto& [line, voice, name, isPlayer, hovered] : dialogue.dialogue) {
 					isPlayer = voice.empty();

--- a/src/NND_API.h
+++ b/src/NND_API.h
@@ -1,0 +1,94 @@
+
+#pragma once
+
+/*
+* For modders: Copy this file into your own project if you wish to use this API
+*/
+namespace NND_API
+{
+	constexpr auto NNDPluginName = "NPCsNamesDistributor";
+
+	// Available NND interface versions
+	enum class InterfaceVersion : uint8_t
+	{
+		kV1,
+
+		/// <summary>
+		/// Introduces a new NameContext kDialogueHistory. Attempting to access it in older versions would return name for kOther context instead.
+		/// </summary>
+		kV2
+	};
+
+	enum class NameContext : uint8_t
+	{
+		kCrosshair = 1,
+		kCrosshairMinion,
+
+		kSubtitles,
+		kDialogue,
+
+		kInventory,
+
+		kBarter,
+
+		kEnemyHUD,
+
+		kOther,
+
+		kDialogueHistory
+	};
+
+	// NND's modder interface
+	class IVNND1
+	{
+	public:
+		/// <summary>
+		/// Retrieves a generated name for given actor appropriate in specified context.
+		/// Note that NND might not have a name for the actor. In this case an empty string will be returned.
+		/// </summary>
+		/// <param name="actor">Actor for which the name should be retrieved.</param>
+		/// <param name="context">Context in which the name needs to be displayed. Depending on context name might either shortened or formatted differently.</param>
+		/// <returns>A name generated for the actor. If actor does not support generated names an empty string will be returned instead.</returns>
+		virtual std::string_view GetName(RE::ActorHandle actor, NameContext context) noexcept = 0;
+
+		/// <summary>
+		/// Retrieves a generated name for given actor appropriate in specified context.
+		/// Note that NND might not have a name for the actor. In this case an empty string will be returned.
+		/// </summary>
+		/// <param name="actor">Actor for which the name should be retrieved.</param>
+		/// <param name="context">Context in which the name needs to be displayed. Depending on context name might either shortened or formatted differently.</param>
+		/// <returns>A name generated for the actor. If actor does not support generated names an empty string will be returned instead.</returns>
+		virtual std::string_view GetName(const RE::Actor* actor, NameContext context) noexcept = 0;
+
+		/// <summary>
+		/// Reveals a real name of the given actor to the player. If player already know actor's name this method does nothing.
+		/// This method can be used to programatically introduce the actor to the player.
+		/// </summary>
+		/// <param name="actor">Actor whos name should be revealed.</param>
+		virtual void RevealName(RE::ActorHandle actor) noexcept = 0;
+
+		/// <summary>
+		/// Reveals a real name of the given actor to the player. If player already know actor's name this method does nothing.
+		/// This method can be used to programatically introduce the actor to the player.
+		/// </summary>
+		/// <param name="actor">Actor whos name should be revealed.</param>
+		virtual void RevealName(RE::Actor* actor) noexcept = 0;
+	};
+
+	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);
+
+	/// <summary>
+	/// Request the NND API interface.
+	/// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll has already been loaded
+	/// </summary>
+	/// <param name="a_interfaceVersion">The interface version to request</param>
+	/// <returns>The pointer to the API singleton, or nullptr if request failed</returns>
+	[[nodiscard]] inline void* RequestPluginAPI(const InterfaceVersion a_interfaceVersion = InterfaceVersion::kV1)
+	{
+		const auto pluginHandle = GetModuleHandle(reinterpret_cast<LPCWSTR>("NPCsNamesDistributor.dll"));
+		if (const _RequestPluginAPI requestAPIFunction = reinterpret_cast<_RequestPluginAPI>(GetProcAddress(pluginHandle, "RequestPluginAPI"))) {
+			return requestAPIFunction(a_interfaceVersion);
+		}
+		return nullptr;
+	}
+}

--- a/src/NPCNameProvider.cpp
+++ b/src/NPCNameProvider.cpp
@@ -1,0 +1,29 @@
+#include "NPCNameProvider.h"
+#include "NND_API.h"
+
+namespace logger = SKSE::log;
+
+const char* NPCNameProvider::GetName(RE::TESObjectREFR* ref) const
+{
+	if (NND) {
+		if (auto actor = ref->As<RE::Actor>(); actor) {
+			if (auto name = NND->GetName(actor, NND_API::NameContext::kDialogueHistory); !name.empty()) {
+				return name.data();
+			}
+		}
+	}
+
+	return ref->GetDisplayFullName();
+}
+
+void NPCNameProvider::RequestAPI()
+{
+	if (!NND) {
+		NND = static_cast<NND_API::IVNND1*>(NND_API::RequestPluginAPI(NND_API::InterfaceVersion::kV2));
+		if (NND) {
+			logger::info("Obtained NND API - {0:x}", reinterpret_cast<uintptr_t>(NND));
+		} else {
+			logger::warn("Failed to obtain NND API");
+		}
+	}
+}

--- a/src/NPCNameProvider.h
+++ b/src/NPCNameProvider.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "NND_API.h"
+
+class NPCNameProvider
+{
+public:
+	static NPCNameProvider* GetSingleton()
+	{
+		static NPCNameProvider singleton;
+		return std::addressof(singleton);
+	}
+
+	const char* GetName(RE::TESObjectREFR* actor) const;
+
+	void RequestAPI();
+
+private:
+	NND_API::IVNND1* NND = nullptr;
+
+	NPCNameProvider() = default;
+	NPCNameProvider(const NPCNameProvider&) = delete;
+	NPCNameProvider(NPCNameProvider&&) = delete;
+
+	~NPCNameProvider() = default;
+
+	NPCNameProvider& operator=(const NPCNameProvider&) = delete;
+	NPCNameProvider& operator=(NPCNameProvider&&) = delete;
+};


### PR DESCRIPTION
This API features a new `kDialogueHistory` context specifically introduced for this mod :) If NND is not detected or failed to provide a custom name then default `GetDisplayFullName` will be used as before.